### PR TITLE
update history to 1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-datagrid":"~2.0.0",
     "react-flexbox":"3.0.0",
     "react-google-maps":"4.2.0",
-    "history":"~1.13.1",
+    "history":"~1.17.0",
     "react-router":"~1.0.2",
     "react-tap-event-plugin":"^0.2.1",
     "sqlite3":"~3.1.1"


### PR DESCRIPTION
fixes npm install:

```
npm ERR! peerinvalid The package history does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-router@1.0.3 wants history@^1.17.0
```