### PR TITLE
Making background-geolocation-console heroku friendly again

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Now visit [http://localhost:8080](http://localhost:8080)
 
 You can deploy easily the app on Heroku by pushing the code to your heroku git repository.
 
-Before this, you will need to create 2 environment variables :
-- `NPM_CONFIG_PRODUCTION = false` : It will tell heroku to install `devDependencies` (and not only `dependencies`), required to build browserify's `bundle.min.js` file
+Before this, you will need to create 3 environment variables :
+- `NPM_CONFIG_PRODUCTION = false` : It will tell heroku to install `devDependencies` (and not only `dependencies`), required to build browserify's `bundle.js` file
 - `GMAP_API_KEY = <PUT YOUR KEY HERE>` : A Google Maps API v3 allowed for your heroku domain (see https://console.developers.google.com)
 
 And to reference both `heroku/nodejs` and `https://github.com/weibeld/heroku-buildpack-run.git` buildpacks (either in the heroku dashboard, or by executing `heroku buildpacks:add --index 1 heroku/nodejs && heroku buildpacks:add --index 2 https://github.com/weibeld/heroku-buildpack-run.git`)

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,7 +1,4 @@
-# Generating js/bundle.min.js file
+# Generating js/bundle.js file
 npm run build
 
-# Replacing stuff for PRODUCTION
-echo "Replacing bundle.js reference into index.html..."
-sed -i "s/js\\/bundle.js/js\\/bundle.min.js/" index.html
 echo "=> Done !"


### PR DESCRIPTION
Since 3a75ee55252afc6e49d0a40e9c298656c9313807, `bundle.min.js` file is not produced anymore (instead, this is `bundle.js` file which is produced)

=> Replacing usage of `bundle.js` by `bundle.min.js` in `index.html` is not required anymore at deploy time.

_(However, not sure if generating a not minified `bundle.js` file is what was expected by 3a75ee55252afc6e49d0a40e9c298656c9313807 move, but at least it simplifies one step of the heroku deployment process)_
