### PR TITLE
Persist into pgsql

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You can deploy easily the app on Heroku by pushing the code to your heroku git r
 Before this, you will need to create 2 environment variables :
 - `NPM_CONFIG_PRODUCTION = false` : It will tell heroku to install `devDependencies` (and not only `dependencies`), required to build browserify's `bundle.min.js` file
 - `GMAP_API_KEY = <PUT YOUR KEY HERE>` : A Google Maps API v3 allowed for your heroku domain (see https://console.developers.google.com)
+- Optionally, `DB_CONNECTION_URL = postgres://<username>:<password>@<hostname>:<port>/<dbname>` if you want to persist locations
+  into a postgresql db (instead of a sqlite db which will be deleted after every heroku shutdown)
 
 And to reference both `heroku/nodejs` and `https://github.com/weibeld/heroku-buildpack-run.git` buildpacks (either in the heroku dashboard, or by executing `heroku buildpacks:add --index 1 heroku/nodejs && heroku buildpacks:add --index 2 https://github.com/weibeld/heroku-buildpack-run.git`)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "history": "~1.17.0",
     "react-router": "~2.7.0",
     "react-tap-event-plugin": "^1.0.0",
-    "sqlite3": "~3.1.1"
+    "sqlite3": "~3.1.1",
+    "pg": "6.1.0",
+    "pg-hstore": "2.3.2",
+    "sequelize": "3.24.1"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.13.2",
@@ -39,7 +42,7 @@
     "server": "node server.js",
     "watch": "watchify -t [ babelify --presets [ react es2015 ] ] js/app.js -o js/bundle.js",
     "build": "browserify . -o js/bundle.js -t [ babelify --presets [ es2015 react ] ] ",
-    "test": "jest"    
+    "test": "jest"
   },
   "author": "Chris Scott, Transistor Software",
   "browserify": {

--- a/server.js
+++ b/server.js
@@ -1,12 +1,16 @@
 var express     = require('express');
 var bodyParser  = require('body-parser')
 var app         = express();
-var sqlite3     = require("sqlite3").verbose();
+var Sequelize   = require('sequelize');
 var fs          = require("fs");
-var dbFile      = "db/background-geolocation.db";
 
-// Init db.
-var dbh = initDB(dbFile);
+// ENVIRONMENT VARIABLES :
+// PORT (optional, defaulted to 8080) : http port server will listen to
+// DB_CONNECTION_URL (defaulted to "sqlite://db/background-geolocation.db") : connection url used to connect to a db
+//    Currently, only postgresql & sqlite dialect are supported
+//    Sample pattern for postgresql connection url : postgres://<username>:<password>@<hostname>:<port>/<dbname>
+
+var sequelize = new Sequelize(process.env.DB_CONNECTION_URL || { dialect: "sqlite", storage: "./db/background-geolocation.db" });
 
 app.disable('etag');
 app.use(express.static('.'));
@@ -70,21 +74,41 @@ var server = app.listen((process.env.PORT || 8080), function () {
   console.log('*************************************************************************', "\n");
 });
 
+
+var LocationModel = sequelize.define("locations", {
+  id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true},
+  uuid: { type: Sequelize.TEXT },
+  device_id: { type: Sequelize.TEXT },
+  device_model: { type: Sequelize.TEXT },
+  latitude: { type: Sequelize.REAL },
+  longitude: { type: Sequelize.REAL },
+  accuracy: { type: Sequelize.INTEGER },
+  altitude: { type: Sequelize.REAL },
+  speed: { type: Sequelize.REAL },
+  heading: { type: Sequelize.REAL },
+  activity_type: { type: Sequelize.TEXT },
+  activity_confidence: { type: Sequelize.INTEGER },
+  battery_level: { type: Sequelize.REAL },
+  battery_is_charging: { type: Sequelize.BOOLEAN },
+  is_moving: { type: Sequelize.BOOLEAN },
+  geofence: { type: Sequelize.TEXT },
+  recorded_at: { type: Sequelize.DATE },
+  created_at: { type: Sequelize.DATE }
+});
+
 /**
 * Device model
 */
 var Device = (function() {
   return {
     all: function(conditions, callback) {
-      var query = "SELECT device_id, device_model FROM locations GROUP BY device_id, device_model ORDER BY recorded_at DESC";
-      var onQuery = function(err, rows) {
-        var rs = [];
-        rows.forEach(function (row) {
-          rs.push(row);
-        });
-        callback(rs);
-      }      
-      dbh.all(query, onQuery);
+      LocationModel.findAll({
+        attributes: [ 'device_id', 'device_model'],
+        group: [ 'device_id', 'device_model' ],
+        order: 'max(recorded_at) DESC'
+      }).then(callback, function(err){
+        console.error("Error while fetching all devices", err);
+      });
     }
   }
 })();
@@ -100,112 +124,75 @@ var Location = (function() {
 
   return {
     all: function(params, callback) {
-      var query = ["SELECT * FROM locations"];
-      var conditions = [];
+      var whereConditions = {};
       if (params.start_date && params.end_date) {
-        conditions.push("recorded_at BETWEEN ? AND ?")
+        whereConditions.recorded_at = { $between: [params.start_date, params.end_date] };
       }
       if (params.device_id && params.device_id !== '') {
-        conditions.push("device_id = ?")
+        whereConditions.device_id = params.device_id;
       }
-      if (conditions.length) {
-        query.push("WHERE " + conditions.join(' AND '));
-      }
-      query.push("ORDER BY recorded_at DESC");
 
-      console.log('- ', query.join(' '), "\n");
-      var onQuery = function(err, rows) {
-        if (err) {
-          console.log('ERROR: ', err);
-          return;
-        }
-        var rs = [];
+      LocationModel.findAll({
+        where: whereConditions,
+        order: 'recorded_at DESC'
+      }).then(function(rows) {
+        var locations = [];
         rows.forEach(function (row) {
-          rs.push(hydrate(row));
+          locations.push(hydrate(row));
         });
-        callback(rs);
-      }
-
-      query = query.join(' ');
-      if (params.device_id && params.start_date && params.end_date) {
-        dbh.all(query, params.start_date, params.end_date, params.device_id, onQuery)
-      } else if (params.start_date && params.end_date) {
-        dbh.all(query, params.start_date, params.end_date, onQuery);
-      } else {
-        dbh.all(query, onQuery);
-      }
+        callback(locations);
+      }, function(err){
+        console.error("Fetch all locations error : ", err);
+      });
     },
     create: function(params) {
       var location  = params.location,
-          now       = new Date(),
-          query     = "INSERT INTO locations (uuid, device_id, device_model, latitude, longitude, accuracy, altitude, speed, heading, activity_type, activity_confidence, battery_level, battery_is_charging, is_moving, geofence, recorded_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-      
-      var sth       = dbh.prepare(query);
-      
-      var insert = function(location) {
+          now       = new Date();
+
+      // Considering we're always working with locations array
+      var locations = location.length?location:[location];
+
+      locations.forEach(function(location){
         var coords = location.coords,
             battery   = location.battery  || {level: null, is_charging: null},
             activity  = location.activity || {type: null, confidence: null},
-            device    = params.device     || {model: "UNKNOWN"};
-            
+            device    = params.device     || {model: "UNKNOWN"},
             geofence  = (location.geofence) ? JSON.stringify(location.geofence) : null;
 
-        sth.run(location.uuid, device.uuid, device.model, coords.latitude, coords.longitude, coords.accuracy, coords.altitude, coords.speed, coords.heading, activity.type, activity.confidence, battery.level, battery.is_charging, location.is_moving, geofence, location.timestamp, now);
-      }
-
-      // Check for batchSync, ie: location: {...} OR location: [...]
-      if (typeof(location.length) === 'number') {
-        // batchSync: true        
-        for (var n=0,len=location.length;n<len;n++) {
-          insert(location[n]);          
-        }
-      } else {        
-        // batchSync: false
-        insert(location);
-      }
-      sth.finalize();
+        LocationModel.create({
+          uuid: location.uuid,
+          device_id: device.uuid,
+          device_model: device.model,
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          accuracy: coords.accuracy,
+          altitude: coords.altitude,
+          speed: coords.speed,
+          heading: coords.heading,
+          activity_type: activity.type,
+          activity_confidence: activity.confidence,
+          battery_level: battery.level,
+          battery_is_charging: battery.is_charging,
+          is_moving: location.is_moving,
+          geofence: geofence,
+          recorded_at: location.timestamp,
+          created_at: now
+        });
+      });
     }
   }
 })();
 
 /**
-* Init / create database
-*/
-function initDB(filename) {
-  if(fs.existsSync(filename)) {
-    return new sqlite3.Database(filename);
-  } else {
-    console.log("Creating DB file.");
-    fs.mkdir("db", function(e) {
-      fs.openSync(filename, "w");
+ * Init / create database
+ */
+sequelize.authenticate()
+    .then(function(err) {
+      console.log('DB Connection has been established successfully.');
+      return LocationModel.sync();
+    }, function(err){
+      console.log('Unable to connect to the database:', err);
+    })
+    .catch(function (err) {
+      console.log('Unable to sync database:', err);
     });
-    
-    
-    var dbh = new sqlite3.Database(filename);  
-
-    var LOCATIONS_COLUMNS = [
-      "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL", 
-      "uuid TEXT",
-      "device_id TEXT",
-      "device_model TEXT",
-      "latitude REAL", 
-      "longitude REAL",
-      "accuracy INTEGER", 
-      "altitude REAL",
-      "speed REAL",
-      "heading REAL",
-      "activity_type TEXT",
-      "activity_confidence INTEGER",
-      "battery_level REAL",
-      "battery_is_charging BOOLEAN",
-      "is_moving BOOLEAN",
-      "geofence TEXT",
-      "recorded_at DATETIME",
-      "created_at DATETIME"
-    ];
-    dbh.serialize(function() {
-      dbh.run("CREATE TABLE locations (" + LOCATIONS_COLUMNS.join(',') + ")");
-    });
-    return dbh;
-  }
-}


### PR DESCRIPTION
Introduced `Sequelize` ORM allowing to fetch & persist data using both `sqlite` (default) or `postgresql`.

It allows to workaround cloud PaaS habit (like heroku) to delete the whole nodejs server when hibernating (note that even with some "pinging" workaround making the app always up, heroku introduced some limitation since June 1st where [free dynos could not run over 18h a day without sleeping](https://devcenter.heroku.com/articles/free-dyno-hour-faq#why-is-heroku-changing-how-free-dynos-work-what-are-the-changes))

With this PR, you can now configure a postgresql datasource using `DB_CONNECTION_URL` environment variable and persist your data into a Postgresql database (like a free one from https://elephantsql.com)
That way, even if your NodeJS app content is cleant, data will remain.
