### PR TITLE
Heroku friendliness after refacto

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run build && node server.js
+web: node server.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node server.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: sed -i "s/maps.googleapis.com\\/maps\\/api\\/js/maps.googleapis.com\\/maps\\/api\\/js?key=$GMAP_API_KEY/" index.html && node server.js
+web: npm run build && node server.js

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ The Background Geolocation [Sample App](https://github.com/transistorsoft/cordov
 
 You should also configure `Settings->autoSync` to `false` while out field-testing as well, so that the app doesn't try syncing each recorded location to the server running on your `localhost`.  Once you return after a test and you're back on your office Wifi, click the **[Sync]** button on the `Settings` screen to upload the cached locations to the **Background Geolocation Console** server.
 
+## Running on Heroku
+
+You can deploy easily the app on Heroku by pushing the code to your heroku git repository.  
+
+Before this, you will need to create 2 environment variables (either in the heroku dashboard, or by executing `heroku config:set <VARIABLE_NAME>=<VARIABLE_VALUE>`) :  
+- `NPM_CONFIG_PRODUCTION = false` : It will tell heroku to install `devDependencies` (and not only `dependencies`), required to build browserify's `bundle.min.js` file
+- `GMAP_API_KEY = <PUT YOUR KEY HERE>` : A Google Maps API v3 allowed for your heroku domain (see https://console.developers.google.com)
+
+And to reference `heroku/nodejs` buildpack (either in the heroku dashboard, or by executing `heroku buildpacks:add --index 1 heroku/nodejs`)
+
 ## Credit
 
 Chris Scott of [Transistor Software](http://transistorsoft.com)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack",
+    "start": "node server.js",
     "server": "node server.js",
     "heroku-postbuild": "webpack -p --config ./webpack.config.js --progress"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack",
-    "server": "node server.js"
+    "server": "node server.js",
+    "heroku-postbuild": "webpack -p --config ./webpack.config.js --progress"
   },
   "author": "Chris Scott, Transistor Software",
   "license": "MIT",

--- a/server.js
+++ b/server.js
@@ -12,6 +12,10 @@ const webpackHotMiddleware  = require('webpack-hot-middleware');
 
 const isDev = true;
 
+process.on('uncaughtException', function(error){
+  console.error("Uncaught error : ", error);
+});
+
 app.disable('etag');
 app.use(express.static('./src/client'));
 app.use(bodyParser.json());

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ app.use(middleware);
 
 const spawn = require('child_process').spawn
 
-var server = app.listen(9000, function () {
+var server = app.listen((process.env.PORT || 9000), function () {
   var host = server.address().address;
   var port = server.address().port;
 

--- a/server.js
+++ b/server.js
@@ -44,8 +44,6 @@ const middleware = [
 
 app.use(middleware);
 
-const spawn = require('child_process').spawn
-
 var server = app.listen((process.env.PORT || 9000), function () {
   var host = server.address().address;
   var port = server.address().port;
@@ -54,9 +52,14 @@ var server = app.listen((process.env.PORT || 9000), function () {
   console.log('║ Background Geolocation Server | port: %s'.green.bold, port);
   console.log('╚═══════════════════════════════════════════════════════════'.green.bold);
 
-  
-  spawn('open', ['http://localhost:' + port]);
-
+  // Spawning dedicated process on opened port.. only if not deployed on heroku
+  if(!process.env.DYNO) {
+      const spawn = require('child_process').spawn;
+      var child = spawn('open', ['http://localhost:' + port]);
+      child.on('error', function(err) {
+          console.error('Error during spawned child process : ', err);
+      });
+  }
 });
 
 

--- a/src/client/components/MapView.js
+++ b/src/client/components/MapView.js
@@ -14,7 +14,7 @@ import {
   Panel
 } from 'react-toolbox';
 
-const API_KEY = "AIzaSyA9j72oZA5SmsA8ugu57pqXwpxh9Sn4xuM";
+const API_KEY = process.env.GMAP_API_KEY || "AIzaSyA9j72oZA5SmsA8ugu57pqXwpxh9Sn4xuM";
 
 class MapView extends Component {  
 

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8" />
 		<title>Background Geolocation Console</title>
-		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-		<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+		<link href="//fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+		<link href="//fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
 		<style>
 			body {
 				margin: 0;


### PR DESCRIPTION
Updated heroku deployment specificities since refactoring having happened recently.

Now that GMAP is a JS react component, it is simpler to reference `GMAP_API_KEY` heroku variable (if defined) inside JS code (no need to use `sed` alongside dedicated heroku buildpack for this ... simply using `process.env.GMAP_API_KEY` in code)

I thus removed `Procfile` file since heroku deployment can now easily be handled by `npm run` scripts :
- `heroku-postbuild` which is called after deployment, and will run `webpack` to build required assets
- `start` which is an heroku convention (see https://devcenter.heroku.com/articles/nodejs-support#default-web-process-type).
  Note that it means `npm run start` and `npm run server` will thus do exactly the same thing : run `server.js` (meaning `npm run server` sounds useless now ... I kept it at the moment but I could remove it (and its references) if you're ok with that)

On heroku, we're not allowed to spawn more than one process on free dynos, that's why I removed `spawn()` call when I identify we're deployed on heroku (`DYNO` environment variable defined)
