### PR TITLE
Move DB location to allow docker better persistence

### DIFF
--- a/src/server/database/define-sequelize-db.js
+++ b/src/server/database/define-sequelize-db.js
@@ -8,5 +8,5 @@ import path from 'path';
 //    Sample pattern for postgresql connection url : postgres://<username>:<password>@<hostname>:<port>/<dbname>
 
 export default new Sequelize(
-  process.env.DATABASE_URL || { dialect: 'sqlite', storage: path.resolve(__dirname, 'background-geolocation.db') }
+  process.env.DATABASE_URL || { dialect: 'sqlite', storage: path.resolve(__dirname, 'db/', 'background-geolocation.db') }
 );


### PR DESCRIPTION
Hey Chris,

As we discussed, here is my suggestion to easy the use of `docker`.
By putting the `db` file in a separate dir we can gain few advantages:
1. easier persistence between docker restarts as we wont need to mention exactly which file to mount
2. Other files in the same dir will be shared to. for example `some-old-backup.db`
3. It will be easier to switch/backup and etc

so when mounting a local dir (with the db) we dont have to exclude other files or include only one