### PR TITLE
Documentation updates (working image, info on app configuration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,30 @@ If you are in an environment that supports opening a web browser, a browser wind
 
 ## Configure The Sample App
 
-The Background Geolocation [Sample App](https://github.com/transistorsoft/cordova-background-geolocation-SampleApp) is perfect for use with this web-application.  To configure the app, simply edit `Settings->url` and set it to `http://<your.ip.ad.dress>:9000/locations`.
+The Background Geolocation [Sample App](https://github.com/transistorsoft/cordova-background-geolocation-SampleApp) is perfect for use with this web-application.  To configure the app, determine your IP address and pick a unique console username, then simply edit `Settings->url` and set it to `http://<your.ip.ad.dress>:9000/locations/<your-console-username>`.
 
-You should also configure `Settings->autoSync` to `false` while out field-testing as well, so that the app doesn't try syncing each recorded location to the server running on your `localhost`.  Once you return after a test and you're back on your office Wifi, click the **[Sync]** button on the `Settings` screen to upload the cached locations to the **Background Geolocation Console** server.
+You may also want to configure `Settings->autoSync` to `false` while out field-testing as well, so that the app doesn't try syncing each recorded location to a possibly unreachable server running on your `localhost`.  Once you return after a test and you're back on your office Wifi, click the **[Sync]** button on the `Settings` screen to upload the cached locations to the **Background Geolocation Console** server.
+
+## Configure Your Own App
+
+As you integrate the background-geolocation plugin with your app, you may find it useful to post locations to the test console to verify your integration.
+
+If you want to post to the tracking console in your own app, it’s very easy: The plugin contains a helper method [#transistorTrackerParams](https://transistorsoft.github.io/react-native-background-geolocation-android/classes/_react_native_background_geolocation_android_.backgroundgeolocation.html#transistortrackerparams) to compose a params config suitable for consumption by the server:
+
+```javascript
+//
+// Configure the BackgroundGeolocation plugin to post to this console
+// after modifying the #url / #params below, visit in your browser:
+// http://<your.ip.ad.dress>:9000/<your-console-username
+//
+let username = 'your-custom-username';
+BackgroundGeolocation.ready({
+  url: 'http://<your-ip-address>/locations/' + <your-console-username>,
+  params: BackgroundGeolocation.transistorTrackerParams()
+}, (state) => {
+  BackgroundGeolocation.start();
+});
+```
 
 ## Running on Heroku
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 > A simple Node server & web app with SQLite database for field-testing & analysis of the [Background Geolocation plugin](https://github.com/transistorsoft/cordova-background-geolocation-lt).
 
-![](https://dl.dropboxusercontent.com/u/2319755/cordova-background-geolocaiton/background-geolocation-console-map.png)
-
-![](https://dl.dropboxusercontent.com/u/2319755/cordova-background-geolocaiton/background-geolocation-console-grid.png)
-
 ## Install
 
 You must have [npm](https://www.npmjs.org/) installed on your computer.
@@ -26,8 +22,6 @@ A browser window will automatically launch the front-end web app.
 ## Configure The Sample App
 
 The Background Geolocation [Sample App](https://github.com/transistorsoft/cordova-background-geolocation-SampleApp) is perfect for use with this web-application.  To configure the app, simply edit `Settings->url` and set it to `http://<your.ip.ad.dress>:9000/locations`.
-
-![](https://dl.dropboxusercontent.com/u/2319755/cordova-background-geolocaiton/settings-url.png)
 
 You should also configure `Settings->autoSync` to `false` while out field-testing as well, so that the app doesn't try syncing each recorded location to the server running on your `localhost`.  Once you return after a test and you're back on your office Wifi, click the **[Sync]** button on the `Settings` screen to upload the cached locations to the **Background Geolocation Console** server.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install
 npm run server
 ```
 
-A browser window will automatically launch the front-end web app.
+If you are in an environment that supports opening a web browser, a browser window will automatically launch the front-end web app at the end of the server startup procedure.
 
 ## Configure The Sample App
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ You must have [npm](https://www.npmjs.org/) installed on your computer.
 From the root project directory run these commands from the command line:
 
 ```bash
-$ npm install
+npm install
 ```
 
 ## Running
 
 ```bash
-$ npm run server
+npm run server
 ```
 
 A browser window will automatically launch the front-end web app.
@@ -30,8 +30,9 @@ You should also configure `Settings->autoSync` to `false` while out field-testin
 You can deploy easily the app on Heroku by pushing the code to your heroku git repository.  
 
 Before this, you will need to create 2 environment variables (either in the heroku dashboard, or by executing `heroku config:set <VARIABLE_NAME>=<VARIABLE_VALUE>`) :  
+
 - `NPM_CONFIG_PRODUCTION = false` : It will tell heroku to install `devDependencies` (and not only `dependencies`), required to build browserify's `bundle.min.js` file
-- `GMAP_API_KEY = <PUT YOUR KEY HERE>` : A Google Maps API v3 allowed for your heroku domain (see https://console.developers.google.com)
+- `GMAP_API_KEY = <PUT YOUR KEY HERE>` : A Google Maps API v3 allowed for your heroku domain (see <https://console.developers.google.com>)
 - Optionally, `DB_CONNECTION_URL = postgres://<username>:<password>@<hostname>:<port>/<dbname>` if you want to persist locations
   into a postgresql db (instead of a sqlite db which will be deleted after every heroku shutdown)
 
@@ -50,4 +51,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > A simple Node server & web app with SQLite database for field-testing & analysis of the [Background Geolocation plugin](https://github.com/transistorsoft/cordova-background-geolocation-lt).
 
+![Screenshot of console web front-end](https://cdn-images-1.medium.com/max/1600/1*LQjGoP0SgXOrqJvjy58EkQ.png)
+
+You may read the news about this [application in our article on Medium](https://medium.com/@transistorsoft/background-geolocation-console-45796532c2ee).
+
 ## Install
 
 You must have [npm](https://www.npmjs.org/) installed on your computer.


### PR DESCRIPTION
As mentioned in #43 - any app that wishes to post to the console needs a username and some device params.

On [the discussion in that issue](https://github.com/transistorsoft/background-geolocation-console/issues/43#issuecomment-469647991) you mentioned these two things:

> See the docs for transistorTrackerParams.

I did! But it wasn't linked in the actual console documentation. I just felt that in an otherwise excellent batch of documentation, that same method link should be mentioned as required where it's required

> This the demo server for the demo app. It’s not meant to be used with your own production app.

No disagreement from me there! But I felt like my best integration path for this module was:

1. Get sample app posting to public test tracker
1. Integrate module into my app, test with posts to public test tracker
1. Have my app post to my own server

The problem was with the second step. My posts weren't showing up on the public tracker from my own app even though it was working from the sample app. Clear problem in my code and it didn't make sense to move on until it was fixed. So I started reading through issues and docs to figure out why not, cloned this repo and ran it locally, and I discovered #43 which showed me the missing ingredients. At about the same time I saw your post on Medium with the sample code, but it wasn't in the console docs, so I thought I might link it too.

While doing those things in this PR I also linted, patched up the images so it's got curb appeal again, and noted the possibility for a startup error.

My integration is successful now (thanks to these samples) and I'm about to buy a license.

Ideally these (or some subset of these) proposed changes from fresh user eyes might help the next person...