### PR TITLE
Update sqlite3 (needed for current AWS Linux AMIs, Ubuntu 18.10 etc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "prettier-eslint": "^6.3.0",
     "prettier-eslint-cli": "^4.1.1",
     "react-hot-loader": "^3.0.0-beta.6",
-    "sqlite3": "~3.1.8",
+    "sqlite3": "~4.0.6",
     "style-loader": "^0.13.1",
     "webpack": "^2.3.3",
     "webpack-dev-middleware": "^1.10.1",


### PR DESCRIPTION
I was unable to install this locally on Ubuntu 18.10 or a standard AWS EC2 Amazon Linux AMI without updating the sqlite3 dependency.

I tested the existing dependency using an npm install on both node lts/dubnium and node current and neither had pre-existing sqlite3 binaries for the current versions as of today, so it fell back to a local build which didn't work.

With this change, there appear to be binaries available for lts/dubnium and current, and my local installation of the console appears to work correctly (accepting, displaying, filtering, deleting locations)

output of install on Ubuntu 18.10 with this change

```
mike@isabela:~/work/react-random/background-geolocation-console (update-sqlite3) % npm install
npm WARN deprecated babel-preset-es2015@6.24.1: 🟟  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update! 
npm WARN deprecated postcss-cssnext@2.11.0: 'postcss-cssnext' has been deprecated in favor of 'postcss-preset-env'. Read more at https://moox.io/blog/deprecating-cssnext/
npm WARN deprecated point-geometry@0.0.0: This module has moved: please install @mapbox/point-geometry instead
npm WARN deprecated browserslist@1.7.7: Browserslist 2 could fail on reading Browserslist >3.0 config used in other tools.
npm WARN deprecated circular-json@0.3.3: CircularJSON is in maintenance only, flatted is its successor.

> sqlite3@4.0.6 install /home/mike/work/react-random/background-geolocation-console/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build

node-pre-gyp WARN Using request for node-pre-gyp https download 
[sqlite3] Success: "/home/mike/work/react-random/background-geolocation-console/node_modules/sqlite3/lib/binding/node-v64-linux-x64/node_sqlite3.node" is installed via remote
npm WARN ajv-keywords@2.1.1 requires a peer of ajv@^5.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN The package postcss-cssnext is included as both a dev and production dependency.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.7 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.7: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

added 1421 packages from 968 contributors and audited 13707 packages in 331.83s
found 6 vulnerabilities (3 low, 1 moderate, 2 high)
  run `npm audit fix` to fix them, or `npm audit` for details
mike@isabela:~/work/react-random/background-geolocation-console (update-sqlite3) % 
```