### PR TITLE
Catch rejected promise if environment doesn't support an opn

### DIFF
--- a/server.js
+++ b/server.js
@@ -72,7 +72,8 @@ process.on('uncaughtException', function (error) {
 
     // Spawning dedicated process on opened port.. only if not deployed on heroku
     if (!process.env.DYNO) {
-      opn(`http://localhost:${port}`);
+      opn(`http://localhost:${port}`)
+        .catch(function (error) { console.log("Optional site open failed:", error); });
     }
   });
 })();


### PR DESCRIPTION
If you try to spin this up on an AWS EC2 node, you'll get an ugly exception about unhandled promise rejections

Some quick research indicates that's fully expected in that environment, and also harmless, so I just catch it with this patch, and note in the message that it was a failure of an optional thing so future people are possibly less surprised