### PR TITLE
Update README to include correct key for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can deploy easily the app on Heroku by pushing the code to your heroku git r
 Before this, you will need to create 2 environment variables (either in the heroku dashboard, or by executing `heroku config:set <VARIABLE_NAME>=<VARIABLE_VALUE>`) :  
 
 - `NPM_CONFIG_PRODUCTION = false` : It will tell heroku to install `devDependencies` (and not only `dependencies`), required to build browserify's `bundle.min.js` file
-- `GMAP_API_KEY = <PUT YOUR KEY HERE>` : A Google Maps API v3 allowed for your heroku domain (see <https://console.developers.google.com>)
+- `GOOGLE_MAPS_API_KEY = <PUT YOUR KEY HERE>` : A Google Maps API v3 allowed for your heroku domain (see <https://console.developers.google.com>)
 - Optionally, `DB_CONNECTION_URL = postgres://<username>:<password>@<hostname>:<port>/<dbname>` if you want to persist locations
   into a postgresql db (instead of a sqlite db which will be deleted after every heroku shutdown)
 


### PR DESCRIPTION
README was claiming that `GMAPS_API_KEY` was required to be set when it should be `GOOGLE_MAPS_API_KEY`.