### PR TITLE
Read keys from Heroku config

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,7 +7,6 @@ import compress from 'compression';
 import 'colors';
 import opn from 'opn';
 
-import { makeKeys } from './libs/jwt';
 import siteApi from './routes/site-api';
 import api from './routes/api-v2';
 import tests from './routes/tests';
@@ -39,7 +38,6 @@ app.use(bodyParser.raw(parserLimits));
 
 (async function () {
   await initializeDatabase();
-  await makeKeys();
 
   app.use(siteApi);
   app.use('/api/site', siteApi);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -12,11 +12,12 @@ import api from './routes/api-v2';
 import tests from './routes/tests';
 
 const isProduction = process.env.NODE_ENV === 'production';
+const prserLimit = process.env.BODY_PARSER_LIMIT || '1mb';
 const port = process.env.PORT || 9000;
 const dyno = process.env.DYNO;
 const app = express();
 const buildPath = resolve(__dirname, '..', '..', 'build');
-const parserLimits = { limit: '1mb', extended: true };
+const parserLimits = { limit: prserLimit, extended: true };
 
 process
   .on('uncaughtException', (err) => {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -12,12 +12,12 @@ import api from './routes/api-v2';
 import tests from './routes/tests';
 
 const isProduction = process.env.NODE_ENV === 'production';
-const prserLimit = process.env.BODY_PARSER_LIMIT || '1mb';
+const parserLimit = process.env.BODY_PARSER_LIMIT || '1mb';
 const port = process.env.PORT || 9000;
 const dyno = process.env.DYNO;
 const app = express();
 const buildPath = resolve(__dirname, '..', '..', 'build');
-const parserLimits = { limit: prserLimit, extended: true };
+const parserLimits = { limit: parserLimit, extended: true };
 
 process
   .on('uncaughtException', (err) => {

--- a/src/server/libs/jwt.js
+++ b/src/server/libs/jwt.js
@@ -7,7 +7,7 @@ export const signOptions = {
   audience: 'client',
 };
 
-const keys = process.env.JWT_PRIVATE_KEY ? rsaGen() : {};
+const keys = !process.env.JWT_PRIVATE_KEY ? rsaGen() : {};
 export const privateKey = process.env.JWT_PRIVATE_KEY || keys.private;
 export const publicKey = process.env.JWT_PUBLIC_KEY || keys.public;
 
@@ -16,6 +16,8 @@ export const getKeys = () => {
     private: privateKey,
     public: publicKey,
   };
+
+  console.info('getKeys', result);
 
   return result;
 };

--- a/src/server/libs/jwt.js
+++ b/src/server/libs/jwt.js
@@ -1,11 +1,5 @@
-import { readFileSync, existsSync, writeFileSync } from 'fs';
-import { resolve } from 'path';
 import jwt from 'jsonwebtoken';
 import rsaGen from 'keypair';
-
-export const keyPath = resolve(__dirname, '..', '..', '..', 'keys');
-export const privateKeyFile = resolve(keyPath, 'private.key');
-export const publicKeyFile = resolve(keyPath, 'public.key');
 
 export const signOptions = {
   issuer: 'transistorsoft',
@@ -13,23 +7,15 @@ export const signOptions = {
   audience: 'client',
 };
 
-export const makeKeys = async () => {
-  if (existsSync(privateKeyFile)) {
-    return;
-  }
-
-  const keys = rsaGen();
-  const options = { flag: 'w', encoding: 'utf8' };
-
-  writeFileSync(privateKeyFile, keys.private, options);
-  writeFileSync(publicKeyFile, keys.public, options);
-};
+const keys = process.env.JWT_PRIVATE_KEY ? rsaGen() : {};
+export const privateKey = process.env.JWT_PRIVATE_KEY || keys.private;
+export const publicKey = process.env.JWT_PUBLIC_KEY || keys.public;
 
 export const getKeys = () => {
-  const result = {};
-
-  result.private = (process.env.JWT_PRIVATE_KEY) ? process.env.JWT_PRIVATE_KEY : readFileSync(privateKeyFile, 'utf8');
-  result.public = (process.env.JWT_PUBLIC_KEY) ? process.env.JWT_PUBLIC_KEY : readFileSync(publicKeyFile, 'utf8');
+  const result = {
+    private: privateKey,
+    public: publicKey,
+  };
 
   return result;
 };

--- a/src/server/libs/jwt.js
+++ b/src/server/libs/jwt.js
@@ -28,8 +28,8 @@ export const makeKeys = async () => {
 export const getKeys = () => {
   const result = {};
 
-  result.private = readFileSync(privateKeyFile, 'utf8');
-  result.public = readFileSync(publicKeyFile, 'utf8');
+  result.private = (process.env.JWT_PRIVATE_KEY) ? process.env.JWT_PRIVATE_KEY : readFileSync(privateKeyFile, 'utf8');
+  result.public = (process.env.JWT_PUBLIC_KEY) ? process.env.JWT_PUBLIC_KEY : readFileSync(publicKeyFile, 'utf8');
 
   return result;
 };

--- a/src/server/libs/jwt.js
+++ b/src/server/libs/jwt.js
@@ -17,8 +17,6 @@ export const getKeys = () => {
     public: publicKey,
   };
 
-  console.info('getKeys', result);
-
   return result;
 };
 


### PR DESCRIPTION
Heroku deletes `keys/private.key`, `keys/public.key` with each server restart, causing existing tokens held by clients to be invalidated.

The keys need to be constant and stored in Heroku config `process.env.JWT_PUBLIC_KEY` / `process.env.JWT.PRIVATE_KEY`.

